### PR TITLE
Fixed bug when updating status of failed orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Contributors: juanescobar06, tubipapilla, jupagar77
 Tags: avify, checkout, orders, payment gateway, woocommerce
 Requires at least: 5.6
 Tested up to: 5.9.2
-Stable tag: 1.0.1
+Stable tag: 1.0.2
 Requires PHP: 7.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -57,9 +57,13 @@ When you sign up for a monthly subscription, our customer success department wil
 * To connect the orders enable in the avify dashboard Integrations > Woocommerce
 ## Changelog 
 
+### 1.0.2
+
+* Fixed bug when updating status of failed orders.
+
 ### 1.0.1 
 
-* Fix minor bug with localization.
+* Fixed minor bug with localization.
 
 ### 1.0.0 
 

--- a/avify-payments-gateway.php
+++ b/avify-payments-gateway.php
@@ -195,7 +195,8 @@ class WC_Avify_Payments_Gateway extends WC_Payment_Gateway_CC {
 		$error_message = '';
 		if (array_key_exists('error', $response)) {
 			$error_message = array_key_exists('displayMessage', $response['error']) ? $response['error']['displayMessage'] :  __('Something went wrong', 'avify-payments');
-			$customer_order->add_order_note('Error: ' . $error_message);
+			$customer_order->add_order_note($error_message);
+			$customer_order->update_status('failed', $error_message);
 			wc_add_notice($error_message, 'error');
 
 			if (defined('WP_DEBUG') && WP_DEBUG) {

--- a/avify-payments-initializer.php
+++ b/avify-payments-initializer.php
@@ -6,7 +6,7 @@ if (!defined('ABSPATH')) exit;
  * Plugin Name: Avify
  * Plugin URI:
  * Description: Connect your WooCommerce account to Avify and send all your orders to one centralized inventory.
- * Version: 1.0.1
+ * Version: 1.0.2
  * Author: Avify
  * Author URI: https://avify.com/
  * Text Domain: avify-payments

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: juanescobar06, tubipapilla, jupagar77
 Tags: avify, checkout, orders, payment gateway, woocommerce
 Requires at least: 5.6
 Tested up to: 5.9.2
-Stable tag: 1.0.1
+Stable tag: 1.0.2
 Requires PHP: 7.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -57,9 +57,13 @@ When you sign up for a monthly subscription, our customer success department wil
 * To connect the orders enable in the avify dashboard Integrations > Woocommerce
 == Changelog ==
 
+### 1.0.2
+
+* Fixed bug when updating status of failed orders.
+
 = 1.0.1 =
 
-* Fix minor bug with localization.
+* Fixed minor bug with localization.
 
 = 1.0.0 =
 


### PR DESCRIPTION
**Why?**
Previously, when an order failed, it was left as "processing" and its status was not updated to "Failed".