### PR TITLE
feat: add country code dropdown to checkout phone field

### DIFF
--- a/assets/avify-phone-intl-overrides.css
+++ b/assets/avify-phone-intl-overrides.css
@@ -1,0 +1,51 @@
+/* intl-tel-input overrides to match Avify checkout form styles */
+
+/* Make the container fill the parent width */
+.avf_form-input-inner .iti {
+  width: 100%;
+}
+
+/* Match the input styles when intl-tel-input adds left padding for the flag */
+.avf_form-input-inner .iti input#avf_billing_tel {
+  padding-left: 52px;
+}
+
+/* Style the flag button to match form height */
+.avf_form-input-inner .iti__country-container {
+  height: 100%;
+}
+
+.avf_form-input-inner .iti__selected-country-primary {
+  padding-left: 8px;
+  padding-right: 4px;
+}
+
+/* Dropdown styling */
+.iti__dropdown-content {
+  border: 1px solid #E2E2E2;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  font-family: "Open Sans", sans-serif;
+  font-size: 14px;
+}
+
+.iti__search-input {
+  font-family: "Open Sans", sans-serif;
+  font-size: 14px;
+  border: 1px solid #E2E2E2;
+  border-radius: 6px;
+  padding: 8px;
+}
+
+.iti__country {
+  padding: 8px 10px;
+}
+
+.iti__country:hover {
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+/* Ensure the dial code in the dropdown is visible */
+.iti__dial-code {
+  color: #626262;
+}

--- a/assets/avify-phone-intl.js
+++ b/assets/avify-phone-intl.js
@@ -1,0 +1,44 @@
+(function () {
+  var input = document.querySelector('#avf_billing_tel');
+  if (!input) return;
+
+  var initialCountry = (window.avfPhoneIntl && window.avfPhoneIntl.country)
+    ? window.avfPhoneIntl.country.toLowerCase()
+    : 'cr';
+
+  var iti = window.intlTelInput(input, {
+    initialCountry: initialCountry,
+    nationalMode: true,
+    autoPlaceholder: 'aggressive',
+    formatAsYouType: true,
+    countrySearch: true,
+    showFlags: true,
+    useFullscreenPopup: false
+  });
+
+  // Before the minified JS reads the value, we set the full international number.
+  // Using capturing phase (3rd arg = true) so our handler runs BEFORE the minified
+  // JS event listeners that are on the bubbling phase.
+  function setFullNumber() {
+    var fullNumber = iti.getNumber();
+    if (fullNumber) {
+      input.value = fullNumber;
+    }
+  }
+
+  var secondStepBtn = document.querySelector('#avf_to_second_step_button');
+  var checkoutBtn = document.querySelector('#avf_checkout_button');
+
+  if (secondStepBtn) {
+    secondStepBtn.addEventListener('click', setFullNumber, true);
+  }
+  if (checkoutBtn) {
+    checkoutBtn.addEventListener('click', setFullNumber, true);
+  }
+
+  // Also intercept form submit as a safety net
+  var form = input.closest('form');
+  if (form) {
+    form.addEventListener('submit', setFullNumber, true);
+  }
+})();

--- a/avify-checkout.php
+++ b/avify-checkout.php
@@ -5,6 +5,20 @@ function load_avify_checkout_scripts() {
         $v = '1.3.7';
         wp_enqueue_script('avify-checkout', plugin_dir_url( __FILE__ ) . '/assets/avify-checkout.js', array('jquery', 'jquery-ui-sortable', 'jquery-ui-resizable'), $v);
         wp_enqueue_style('avify-checkout', plugin_dir_url( __FILE__ ) . '/assets/avify-checkout.css', false, $v);
+
+        // intl-tel-input library (country code dropdown for phone field)
+        wp_enqueue_style('intl-tel-input', 'https://cdn.jsdelivr.net/npm/intl-tel-input@25.3.1/build/css/intlTelInput.min.css', array(), '25.3.1');
+        wp_enqueue_script('intl-tel-input', 'https://cdn.jsdelivr.net/npm/intl-tel-input@25.3.1/build/js/intlTelInput.min.js', array(), '25.3.1', true);
+
+        // Our custom overrides and initialization
+        wp_enqueue_style('avify-phone-intl-overrides', plugin_dir_url( __FILE__ ) . '/assets/avify-phone-intl-overrides.css', array('intl-tel-input'), $v);
+        wp_enqueue_script('avify-phone-intl', plugin_dir_url( __FILE__ ) . '/assets/avify-phone-intl.js', array('intl-tel-input'), $v, true);
+
+        // Pass the WooCommerce base country to our JS
+        $base_country = function_exists('WC') ? WC()->countries->get_base_country() : 'CR';
+        wp_localize_script('avify-phone-intl', 'avfPhoneIntl', array(
+            'country' => strtolower($base_country),
+        ));
     }
 }
 add_action('wp_enqueue_scripts', 'load_avify_checkout_scripts');

--- a/templates/checkout.php
+++ b/templates/checkout.php
@@ -140,7 +140,7 @@ $cart = WC()->cart;
                                             </div>
 
                                             <div class="avf_form-input-inner">
-                                                <input type="text" id="avf_billing_tel">
+                                                <input type="tel" id="avf_billing_tel">
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
**What?**
Added a country code dropdown (with flags and search) to the phone number field in the Avify checkout form, using the [intl-tel-input](https://github.com/jackocnr/intl-tel-input) library (v25.3.1).

**Why?**
The phone field was a plain text input with no way to select a country code. Customers from different countries had no clear way to indicate their country code, which could lead to invalid phone numbers being submitted.

**How?**
- Loaded intl-tel-input CSS + JS from jsDelivr CDN in `avify-checkout.php`
- Created `assets/avify-phone-intl.js` to initialize the library on `#avf_billing_tel` with the store's base country as default
- Used capturing-phase click handlers on the "Continue" and "Place Order" buttons so the full international number (e.g. `+506 87654321`) is set in the input *before* the existing minified JS reads it
- Created `assets/avify-phone-intl-overrides.css` to match the dropdown styles with the existing form design (borders, radius, font)
- Changed phone input `type="text"` → `type="tel"` for better mobile keyboard

**Files changed:**
- `avify-checkout.php` — enqueue new assets + pass WooCommerce base country to JS
- `templates/checkout.php` — input type text → tel
- `assets/avify-phone-intl.js` — NEW: library init + capturing-phase handlers
- `assets/avify-phone-intl-overrides.css` — NEW: style overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)